### PR TITLE
Release/v1.2.2

### DIFF
--- a/encoding/decode_AttributeValue.go
+++ b/encoding/decode_AttributeValue.go
@@ -607,7 +607,6 @@ func UnmarshalUnixPtr(av ddb.AttributeValue, v **time.Time) error {
 	return nil
 }
 
-
 // UnmarshalUnix unmarshals an AttributeValue into the given value
 func UnmarshalUnix(av ddb.AttributeValue, v *time.Time) error {
 	return UnmarshalUnixPtr(av, &v)
@@ -624,6 +623,42 @@ func UnixUnmarshaler(v *time.Time) UnmarshalerFunc {
 func UnixPtrUnmarshaler(v **time.Time) UnmarshalerFunc {
 	return func(av ddb.AttributeValue) error {
 		return UnmarshalUnixPtr(av, v)
+	}
+}
+
+// UnmarshalDurationPtr unmarshals an AttributeValue into the given value
+func UnmarshalDurationPtr(av ddb.AttributeValue, v **time.Duration) error {
+	intV := new(int64)
+
+	if err := UnmarshalInt64Ptr(av, &intV); err != nil {
+		return err
+	}
+
+	if *v == nil {
+		*v = new(time.Duration)
+	}
+
+	**v = time.Duration(*intV)
+
+	return nil
+}
+
+// UnmarshalDuration unmarshals an AttributeValue into the given value
+func UnmarshalDuration(av ddb.AttributeValue, v *time.Duration) error {
+	return UnmarshalDurationPtr(av, &v)
+}
+
+// DurationUnmarshaler returns a UnmarshalerFunc func that will unmarshal an AttributeValue into the given ptr
+func DurationUnmarshaler(v *time.Duration) UnmarshalerFunc {
+	return func(av ddb.AttributeValue) error {
+		return UnmarshalDuration(av, v)
+	}
+}
+
+// DurationPtrUnmarshaler returns a UnmarshalerFunc func that will unmarshal an AttributeValue into the given ptr
+func DurationPtrUnmarshaler(v **time.Duration) UnmarshalerFunc {
+	return func(av ddb.AttributeValue) error {
+		return UnmarshalDurationPtr(av, v)
 	}
 }
 

--- a/encoding/encode_AttributeValue.go
+++ b/encoding/encode_AttributeValue.go
@@ -3,6 +3,7 @@ package encoding
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	ddb "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"strconv"
@@ -42,7 +43,7 @@ func (em ValueMarshalMap) MarshalMap() (map[string]ddb.AttributeValue, error) {
 	for k, v := range em {
 		av, err := v.MarshalDynamoDBAttributeValue()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error encoding field %s: %s", k, err)
 		}
 
 		if av != nil {
@@ -58,7 +59,7 @@ func (em ValueMarshalMap) MarshalToMap(input map[string]ddb.AttributeValue) erro
 	for k, v := range em {
 		av, err := v.MarshalDynamoDBAttributeValue()
 		if err != nil {
-			return err
+			return fmt.Errorf("error encoding field %s: %s", k, err)
 		}
 
 		if av != nil {

--- a/encoding/encode_AttributeValue.go
+++ b/encoding/encode_AttributeValue.go
@@ -350,3 +350,37 @@ func UnixMarshaler(v *time.Time, mode NilMode) MarshalFunc {
 		return MarshalUnix(v, mode)
 	}
 }
+
+// MarshalDuration marshals an AttributeValue into the given value
+func MarshalDuration(v *time.Duration, mode NilMode) (ddb.AttributeValue, error) {
+	if v == nil {
+		return numericNil(mode)
+	}
+
+	intV := v.Nanoseconds()
+
+	return MarshalInt64(&intV, mode)
+}
+
+// DurationMarshaler returns a MarshalFunc func that will generate an AttributeValue
+func DurationMarshaler(v *time.Duration, mode NilMode) MarshalFunc {
+	return func() (ddb.AttributeValue, error) {
+		return MarshalDuration(v, mode)
+	}
+}
+
+// MarshalStringSlice marshals an AttributeValue into the given value
+func MarshalStringSlice(v *[]string, mode NilMode) (ddb.AttributeValue, error) {
+	if v == nil {
+		return stringNil(mode)
+	}
+
+	return &ddb.AttributeValueMemberSS{Value: *v}, nil
+}
+
+// StringSliceMarshaler returns a MarshalFunc func that will generate an AttributeValue
+func StringSliceMarshaler(v *[]string, mode NilMode) MarshalFunc {
+	return func() (ddb.AttributeValue, error) {
+		return MarshalStringSlice(v, mode)
+	}
+}


### PR DESCRIPTION
- added more verbose errors to value encoding and decoding
- added value marshalers and unmarshalers for `time.Duration` and `[]string`